### PR TITLE
Got rid of, "hello"

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,4 +45,3 @@ Create a project meta-record using the template from file required_fields_projec
 
 ## Thanks
 Special thanks goes out to [Chris Mattmann (NASA JPL)](https://github.com/chrismattmann), Sean Kelly (NASA JPL) and [Eric Whyne (DARPA)](https://github.com/ericwhyne) for their inspiration for this effort.
-hello


### PR DESCRIPTION
Someone decided to type, "hello" with no context and I decided to get rid of it because it had no reason to exist.