### PR TITLE
Normalize naming of NASA Open Source Agreement

### DIFF
--- a/code.json
+++ b/code.json
@@ -71774,7 +71774,7 @@
                 "licenses": [
                     {
                         "URL": "https://github.com/nasa/webgs/blob/master/LICENSE",
-                        "name": "NASA Open Source Agreement"
+                        "name": "NASA Open Source"
                     }
                 ],
                 "usageType": "openSource"
@@ -71835,7 +71835,7 @@
                 "licenses": [
                     {
                         "URL": "https://github.com/nasa/vscode-pvs/blob/master/LICENSE",
-                        "name": "NASA Open Source Agreement"
+                        "name": "NASA Open Source"
                     }
                 ],
                 "usageType": "openSource"
@@ -71888,7 +71888,7 @@
                 "licenses": [
                     {
                         "URL": "https://github.com/nasa/cpr/blob/master/LICENSE",
-                        "name": "NASA Open Source Agreement"
+                        "name": "NASA Open Source"
                     }
                 ],
                 "usageType": "openSource"


### PR DESCRIPTION
There were two names given for the NASA Open Source Agreement (NOSA):

* 565 instances of "NASA Open Source"
* 3 instances of "NASA Open Source Agreement"

Normalize those 3 instances to the spelling "NASA Open Source" for consistency and easier analysis.